### PR TITLE
make sure collect for data.frame propagates CRS

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -64,7 +64,12 @@ geoarrow_collect.data.frame <- function(x, ..., handler = NULL, metadata = NULL)
   }
 
   col_handleable <- vapply(x, is_handleable_column, logical(1))
-  x[col_handleable] <- lapply(x[col_handleable], wk_handle_wrapper, handler)
+  x[col_handleable] <- Map(
+    wk::wk_set_crs,
+    lapply(x[col_handleable], wk_handle_wrapper, handler),
+    lapply(x[col_handleable], wk::wk_crs)
+  )
+
   x
 }
 

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -163,6 +163,14 @@ test_that("geoarrow_collect() works with data.frame", {
     ),
     data.frame(a = 1, b = wk::xy(0, 1))
   )
+
+  expect_identical(
+    geoarrow_collect(
+      data.frame(a = 1, b = wk::wkt("POINT (0 1)", crs = "EPSG:32620")),
+      handler = wk::xy_writer()
+    ),
+    data.frame(a = 1, b = wk::xy(0, 1, crs = "EPSG:32620"))
+  )
 })
 
 test_that("arrow::read|write_ipc_stream() just works with handleables", {


### PR DESCRIPTION
Before this PR:

``` r
geoarrow::geoarrow_collect(
      data.frame(a = 1, b = wk::wkt("POINT (0 1)", crs = "EPSG:32620")),
      handler = wk::xy_writer()
    ) |> wk::wk_crs()
#> NULL
```

After this PR:

``` r
geoarrow::geoarrow_collect(
      data.frame(a = 1, b = wk::wkt("POINT (0 1)", crs = "EPSG:32620")),
      handler = wk::xy_writer()
    ) |> wk::wk_crs()
#> [1] "EPSG:32620"
```

<sup>Created on 2022-05-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>