### PR TITLE
Better sf conversion for Arrow table-like things

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -14,7 +14,7 @@
 #'   in the file.
 #' @param trans A function to be applied to each chunk after it has been
 #'   collected into a data frame.
-#' @inheritDotParams arrow::write_parquet
+#' @inheritDotParams arrow::read_parquet
 #'
 #' @return The result of [arrow::read_parquet()], with geometry
 #'   columns processed according to `handler`.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -19,6 +19,14 @@
       s3_register("arrow::as_arrow_array", cls, as_arrow_array_handleable)
       s3_register("arrow::infer_type", cls, infer_type_handleable)
     }
+
+    table_like_things <- c("arrow_dplyr_query", "RecordBatch", "Table", "Dataset")
+    for (cls in table_like_things) {
+      s3_register("sf::st_as_sf", cls, st_as_sf.ArrowTabular)
+      s3_register("sf::st_geometry", cls, st_geometry.ArrowTabular)
+      s3_register("sf::st_bbox", cls, st_bbox.ArrowTabular)
+      s3_register("sf::st_crs", cls, st_crs.ArrowTabular)
+    }
   }
 }
 

--- a/man/read_geoparquet.Rd
+++ b/man/read_geoparquet.Rd
@@ -45,35 +45,13 @@ geoarrow_collect(x, ..., handler = NULL, metadata = NULL)
 \code{\link[arrow:read_ipc_stream]{arrow::read_ipc_stream()}}.}
 
 \item{...}{
-  Arguments passed on to \code{\link[arrow:write_parquet]{arrow::write_parquet}}
+  Arguments passed on to \code{\link[arrow:read_parquet]{arrow::read_parquet}}
   \describe{
-    \item{\code{sink}}{A string file path, URI, or \link[arrow]{OutputStream}, or path in a file
-system (\code{SubTreeFileSystem})}
-    \item{\code{chunk_size}}{how many rows of data to write to disk at once. This
-directly corresponds to how many rows will be in each row group in parquet.
-If \code{NULL}, a best guess will be made for optimal size (based on the number of
-columns and number of rows), though if the data has fewer than 250 million
-cells (rows x cols), then the total number of rows is used.}
-    \item{\code{version}}{parquet version, "1.0" or "2.0". Default "1.0". Numeric values
-are coerced to character.}
-    \item{\code{compression}}{compression algorithm. Default "snappy". See details.}
-    \item{\code{compression_level}}{compression level. Meaning depends on compression algorithm}
-    \item{\code{use_dictionary}}{Specify if we should use dictionary encoding. Default \code{TRUE}}
-    \item{\code{write_statistics}}{Specify if we should write statistics. Default \code{TRUE}}
-    \item{\code{data_page_size}}{Set a target threshold for the approximate encoded
-size of data pages within a column chunk (in bytes). Default 1 MiB.}
-    \item{\code{use_deprecated_int96_timestamps}}{Write timestamps to INT96 Parquet format. Default \code{FALSE}.}
-    \item{\code{coerce_timestamps}}{Cast timestamps a particular resolution. Can be
-\code{NULL}, "ms" or "us". Default \code{NULL} (no casting)}
-    \item{\code{allow_truncated_timestamps}}{Allow loss of data when coercing timestamps to a
-particular resolution. E.g. if microsecond or nanosecond data is lost when coercing
-to "ms", do not raise an exception}
-    \item{\code{properties}}{A \code{ParquetWriterProperties} object, used instead of the options
-enumerated in this function's signature. Providing \code{properties} as an argument
-is deprecated; if you need to assemble \code{ParquetWriterProperties} outside
-of \code{write_parquet()}, use \code{ParquetFileWriter} instead.}
-    \item{\code{arrow_properties}}{A \code{ParquetArrowWriterProperties} object. Like
-\code{properties}, this argument is deprecated.}
+    \item{\code{col_select}}{A character vector of column names to keep, as in the
+"select" argument to \code{data.table::fread()}, or a
+\link[tidyselect:vars_select]{tidy selection specification}
+of columns, as used in \code{dplyr::select()}.}
+    \item{\code{props}}{\link[arrow]{ParquetArrowReaderProperties}}
   }}
 
 \item{x}{An object to collect into a data.frame, converting geometry

--- a/tests/testthat/test-pkg-sf.R
+++ b/tests/testthat/test-pkg-sf.R
@@ -12,6 +12,140 @@ test_that("st_* methods work for geoarrow_vctr", {
   )
 })
 
+test_that("st_geometry() methods work for Arrow table-like things", {
+  skip_if_not_installed("sf")
+  skip_if_not(has_arrow_with_extension_type())
+
+  vctr <- geoarrow(wk::wkt("POINT (0 1)", crs = "OGC:CRS84"))
+  table <- arrow::arrow_table(geom = vctr)
+  batch <- arrow::record_batch(geom = vctr)
+  dataset <- arrow::InMemoryDataset$create(table)
+  query <- dplyr::filter(table, arrow::Expression$scalar(TRUE))
+
+  expect_identical(
+    sf::st_geometry(table),
+    sf::st_as_sfc("POINT (0 1)", crs = sf::st_crs("OGC:CRS84"))
+  )
+
+  expect_identical(
+    sf::st_geometry(batch),
+    sf::st_as_sfc("POINT (0 1)", crs = sf::st_crs("OGC:CRS84"))
+  )
+
+  expect_identical(
+    sf::st_geometry(dataset),
+    sf::st_as_sfc("POINT (0 1)", crs = sf::st_crs("OGC:CRS84"))
+  )
+
+  expect_identical(
+    sf::st_geometry(query),
+    sf::st_as_sfc("POINT (0 1)", crs = sf::st_crs("OGC:CRS84"))
+  )
+})
+
+test_that("st_crs() methods work for Arrow table-like things", {
+  skip_if_not_installed("sf")
+  skip_if_not(has_arrow_with_extension_type())
+
+  vctr <- geoarrow(wk::wkt("POINT (0 1)", crs = "OGC:CRS84"))
+  table <- arrow::arrow_table(geom = vctr)
+  batch <- arrow::record_batch(geom = vctr)
+  dataset <- arrow::InMemoryDataset$create(table)
+  query <- dplyr::filter(table, arrow::Expression$scalar(TRUE))
+
+  expect_identical(
+    sf::st_crs(table),
+    sf::st_crs("OGC:CRS84")
+  )
+
+  expect_identical(
+    sf::st_crs(batch),
+    sf::st_crs("OGC:CRS84")
+  )
+
+  expect_identical(
+    sf::st_crs(dataset),
+    sf::st_crs("OGC:CRS84")
+  )
+
+  expect_identical(
+    sf::st_crs(query),
+    sf::st_crs("OGC:CRS84")
+  )
+})
+
+
+test_that("st_crs() methods work for Arrow table-like things", {
+  skip_if_not_installed("sf")
+  skip_if_not(has_arrow_with_extension_type())
+
+  vctr <- geoarrow(wk::wkt("POINT (0 1)", crs = "OGC:CRS84"))
+  table <- arrow::arrow_table(geom = vctr)
+  batch <- arrow::record_batch(geom = vctr)
+  dataset <- arrow::InMemoryDataset$create(table)
+  query <- dplyr::filter(table, arrow::Expression$scalar(TRUE))
+
+  bbox <- sf::st_bbox(wk::rct(0, 1, 0, 1, crs = "OGC:CRS84"))
+
+  expect_identical(
+    sf::st_bbox(table),
+    bbox
+  )
+
+  expect_identical(
+    sf::st_bbox(batch),
+    bbox
+  )
+
+  expect_identical(
+    sf::st_bbox(dataset),
+    bbox
+  )
+
+  expect_identical(
+    sf::st_bbox(query),
+    bbox
+  )
+})
+
+test_that("st_as_sf() methods work for Arrow table-like things", {
+  skip_if_not_installed("sf")
+  skip_if_not(has_arrow_with_extension_type())
+
+  vctr <- geoarrow(wk::wkt("POINT (0 1)", crs = "OGC:CRS84"))
+  table <- arrow::arrow_table(geometry = vctr)
+  batch <- arrow::record_batch(geometry = vctr)
+  dataset <- arrow::InMemoryDataset$create(table)
+  query <- dplyr::filter(table, arrow::Expression$scalar(TRUE))
+
+  sf_tbl <- sf::st_as_sf(
+    data.frame(
+      geom = sf::st_as_sfc("POINT (0 1)", crs = sf::st_crs("OGC:CRS84"))
+    )
+  )
+
+  expect_identical(
+    sf::st_as_sf(table),
+    sf_tbl
+  )
+
+  expect_identical(
+    sf::st_as_sf(batch),
+    sf_tbl
+  )
+
+  expect_equal(
+    sf::st_as_sf(dataset),
+    sf_tbl,
+    ignore_attr = TRUE
+  )
+
+  expect_identical(
+    sf::st_as_sf(query),
+    sf_tbl
+  )
+})
+
 test_that("geoarrow_collect_sf() works on a data.frame", {
   skip_if_not_installed("sf")
 
@@ -40,7 +174,6 @@ test_that("as_arrow_table() works for sf objects", {
   metadata <- jsonlite::fromJSON(table$metadata$geo)
   expect_identical(metadata$columns$geometry$encoding, "geoarrow.point")
 })
-
 
 test_that("read_geoparquet_sf() works", {
   skip_if_not(has_arrow_extension_type())


### PR DESCRIPTION
``` r
library(geoarrow)
library(sf)
#> Linking to GEOS 3.9.1, GDAL 3.2.3, PROJ 7.2.1

vctr <- geoarrow(wk::wkt("POINT (0 1)", crs = "OGC:CRS84"))
table <- arrow::arrow_table(geom = vctr)
batch <- arrow::record_batch(geom = vctr)
dataset <- arrow::InMemoryDataset$create(table)
query <- dplyr::filter(table, arrow::Expression$scalar(TRUE))

st_crs(query)
#> Coordinate Reference System:
#>   User input: OGC:CRS84 
#>   wkt:
#> GEOGCRS["WGS 84",
#>     DATUM["World Geodetic System 1984",
#>         ELLIPSOID["WGS 84",6378137,298.257223563,
#>             LENGTHUNIT["metre",1]],
#>         ID["EPSG",6326]],
#>     PRIMEM["Greenwich",0,
#>         ANGLEUNIT["degree",0.0174532925199433],
#>         ID["EPSG",8901]],
#>     CS[ellipsoidal,2],
#>         AXIS["longitude",east,
#>             ORDER[1],
#>             ANGLEUNIT["degree",0.0174532925199433,
#>                 ID["EPSG",9122]]],
#>         AXIS["latitude",north,
#>             ORDER[2],
#>             ANGLEUNIT["degree",0.0174532925199433,
#>                 ID["EPSG",9122]]]]
st_bbox(query)
#> xmin ymin xmax ymax 
#>    0    1    0    1
st_geometry(query)
#> Geometry set for 1 feature 
#> Geometry type: POINT
#> Dimension:     XY
#> Bounding box:  xmin: 0 ymin: 1 xmax: 0 ymax: 1
#> Geodetic CRS:  WGS 84
#> POINT (0 1)
st_as_sf(query)
#> Simple feature collection with 1 feature and 0 fields
#> Geometry type: POINT
#> Dimension:     XY
#> Bounding box:  xmin: 0 ymin: 1 xmax: 0 ymax: 1
#> Geodetic CRS:  WGS 84
#>          geom
#> 1 POINT (0 1)
```

<sup>Created on 2022-05-20 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>