### PR TITLE
chore: Update vendored nanoarrow

### DIFF
--- a/src/nanoarrow.c
+++ b/src/nanoarrow.c
@@ -22,6 +22,29 @@
 #include <stdlib.h>
 #include <string.h>
 
+// For thread safe shared buffers we need C11 + stdatomic.h
+// Can compile with -DNANOARROW_USE_STDATOMIC=0 or 1 to override
+// automatic detection
+#if !defined(NANOARROW_USE_STDATOMIC)
+#define NANOARROW_USE_STDATOMIC 0
+
+// Check for C11
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+
+// Check for GCC 4.8, which doesn't include stdatomic.h but does
+// not define __STDC_NO_ATOMICS__
+#if defined(__clang__) || !defined(__GNUC__) || __GNUC__ >= 5
+
+#if !defined(__STDC_NO_ATOMICS__)
+#include <stdatomic.h>
+#undef NANOARROW_USE_STDATOMIC
+#define NANOARROW_USE_STDATOMIC 1
+#endif
+#endif
+#endif
+
+#endif
+
 #include "nanoarrow/nanoarrow.h"
 
 const char* ArrowNanoarrowVersion(void) { return NANOARROW_VERSION; }
@@ -274,6 +297,224 @@ struct ArrowBufferAllocator ArrowBufferDeallocator(
   allocator.free = custom_free;
   allocator.private_data = private_data;
   return allocator;
+}
+
+#if NANOARROW_USE_STDATOMIC
+struct ArrowSharedBufferPrivate {
+  struct ArrowBuffer src;
+  atomic_long reference_count;
+};
+
+static int64_t ArrowSharedBufferUpdate(struct ArrowSharedBufferPrivate* private_data,
+                                       int delta) {
+  int64_t old_count = atomic_fetch_add(&private_data->reference_count, delta);
+  return old_count + delta;
+}
+
+static void ArrowSharedBufferSet(struct ArrowSharedBufferPrivate* private_data,
+                                 int64_t count) {
+  atomic_store(&private_data->reference_count, count);
+}
+
+int ArrowSharedBufferIsThreadSafe(void) { return 1; }
+
+struct ArrowSharedArrayPrivate {
+  struct ArrowArray src;
+  atomic_long reference_count;
+};
+
+static int64_t ArrowSharedArrayUpdate(struct ArrowSharedArrayPrivate* private_data,
+                                      int delta) {
+  int64_t old_count = atomic_fetch_add(&private_data->reference_count, delta);
+  return old_count + delta;
+}
+
+static void ArrowSharedArraySet(struct ArrowSharedArrayPrivate* private_data,
+                                int64_t count) {
+  atomic_store(&private_data->reference_count, count);
+}
+#else
+struct ArrowSharedBufferPrivate {
+  struct ArrowBuffer src;
+  int64_t reference_count;
+};
+
+static int64_t ArrowSharedBufferUpdate(struct ArrowSharedBufferPrivate* private_data,
+                                       int delta) {
+  private_data->reference_count += delta;
+  return private_data->reference_count;
+}
+
+static void ArrowSharedBufferSet(struct ArrowSharedBufferPrivate* private_data,
+                                 int64_t count) {
+  private_data->reference_count = count;
+}
+
+int ArrowSharedBufferIsThreadSafe(void) { return 0; }
+
+struct ArrowSharedArrayPrivate {
+  struct ArrowArray src;
+  int64_t reference_count;
+};
+
+static int64_t ArrowSharedArrayUpdate(struct ArrowSharedArrayPrivate* private_data,
+                                      int delta) {
+  private_data->reference_count += delta;
+  return private_data->reference_count;
+}
+
+static void ArrowSharedArraySet(struct ArrowSharedArrayPrivate* private_data,
+                                int64_t count) {
+  private_data->reference_count = count;
+}
+#endif
+
+static void ArrowSharedBufferFree(struct ArrowBufferAllocator* allocator, uint8_t* ptr,
+                                  int64_t size) {
+  NANOARROW_UNUSED(allocator);
+  NANOARROW_UNUSED(ptr);
+  NANOARROW_UNUSED(size);
+
+  struct ArrowSharedBufferPrivate* private_data =
+      (struct ArrowSharedBufferPrivate*)allocator->private_data;
+
+  if (ArrowSharedBufferUpdate(private_data, -1) == 0) {
+    ArrowBufferReset(&private_data->src);
+    ArrowFree(private_data);
+  }
+}
+
+static void ArrowSharedArrayBufferFree(struct ArrowBufferAllocator* allocator,
+                                       uint8_t* ptr, int64_t size) {
+  NANOARROW_UNUSED(ptr);
+  NANOARROW_UNUSED(size);
+
+  struct ArrowSharedArrayPrivate* private_data =
+      (struct ArrowSharedArrayPrivate*)allocator->private_data;
+
+  if (ArrowSharedArrayUpdate(private_data, -1) == 0) {
+    if (private_data->src.release != NULL) {
+      ArrowArrayRelease(&private_data->src);
+    }
+    ArrowFree(private_data);
+  }
+}
+
+ArrowErrorCode ArrowSharedBufferInit(struct ArrowBuffer* shared,
+                                     struct ArrowBuffer* src) {
+  if (src->data == NULL) {
+    ArrowBufferMove(src, shared);
+    return NANOARROW_OK;
+  }
+
+  struct ArrowSharedBufferPrivate* private_data =
+      (struct ArrowSharedBufferPrivate*)ArrowMalloc(
+          sizeof(struct ArrowSharedBufferPrivate));
+  if (private_data == NULL) {
+    return ENOMEM;
+  }
+
+  ArrowBufferMove(src, &private_data->src);
+  ArrowSharedBufferSet(private_data, 1);
+
+  ArrowBufferInit(shared);
+  shared->data = private_data->src.data;
+  shared->size_bytes = private_data->src.size_bytes;
+  // Don't expose any extra capcity from src so that any calls to ArrowBufferAppend
+  // on this buffer will fail.
+  shared->capacity_bytes = private_data->src.size_bytes;
+  shared->allocator = ArrowBufferDeallocator(&ArrowSharedBufferFree, private_data);
+  return NANOARROW_OK;
+}
+
+int ArrowIsSharedBuffer(struct ArrowBuffer* buffer) {
+  return buffer->allocator.free == &ArrowSharedBufferFree ||
+         buffer->allocator.free == &ArrowSharedArrayBufferFree;
+}
+
+ArrowErrorCode ArrowSharedBufferClone(struct ArrowBuffer* shared,
+                                      struct ArrowBuffer* shared_out) {
+  if (shared->size_bytes == 0) {
+    ArrowBufferInit(shared_out);
+    return NANOARROW_OK;
+  }
+
+  if (shared->allocator.free == &ArrowSharedBufferFree) {
+    struct ArrowSharedBufferPrivate* private_data =
+        (struct ArrowSharedBufferPrivate*)shared->allocator.private_data;
+    ArrowSharedBufferUpdate(private_data, 1);
+    memcpy(shared_out, shared, sizeof(struct ArrowBuffer));
+    return NANOARROW_OK;
+  }
+
+  if (shared->allocator.free == &ArrowSharedArrayBufferFree) {
+    struct ArrowSharedArrayPrivate* private_data =
+        (struct ArrowSharedArrayPrivate*)shared->allocator.private_data;
+    ArrowSharedArrayUpdate(private_data, 1);
+    memcpy(shared_out, shared, sizeof(struct ArrowBuffer));
+    return NANOARROW_OK;
+  }
+
+  return EINVAL;
+}
+
+ArrowErrorCode ArrowSharedArrayInit(struct ArrowSharedArray* shared,
+                                    struct ArrowArray* src) {
+  struct ArrowSharedArrayPrivate* private_data =
+      (struct ArrowSharedArrayPrivate*)ArrowMalloc(
+          sizeof(struct ArrowSharedArrayPrivate));
+  if (private_data == NULL) {
+    return ENOMEM;
+  }
+
+  ArrowArrayMove(src, &private_data->src);
+  ArrowSharedArraySet(private_data, 1);
+  shared->private_data = private_data;
+  return NANOARROW_OK;
+}
+
+void ArrowSharedArrayRelease(struct ArrowSharedArray* shared) {
+  if (shared->private_data == NULL) {
+    return;
+  }
+
+  struct ArrowSharedArrayPrivate* private_data =
+      (struct ArrowSharedArrayPrivate*)shared->private_data;
+
+  if (ArrowSharedArrayUpdate(private_data, -1) == 0) {
+    if (private_data->src.release != NULL) {
+      ArrowArrayRelease(&private_data->src);
+    }
+    ArrowFree(private_data);
+  }
+
+  shared->private_data = NULL;
+}
+
+ArrowErrorCode ArrowSharedArrayBuffer(struct ArrowSharedArray* shared, int64_t i,
+                                      struct ArrowBuffer* out) {
+  struct ArrowSharedArrayPrivate* private_data =
+      (struct ArrowSharedArrayPrivate*)shared->private_data;
+  NANOARROW_DCHECK(i >= 0 && i < private_data->src.n_buffers);
+
+  ArrowSharedArrayUpdate(private_data, 1);
+  ArrowBufferInit(out);
+
+  if (ArrowArrayIsInternal(&private_data->src)) {
+    // The source array was built with nanoarrow, so we can get buffer size info
+    struct ArrowBuffer* src = ArrowArrayBuffer(&private_data->src, i);
+    out->data = src->data;
+    out->size_bytes = src->size_bytes;
+    out->capacity_bytes = src->size_bytes;
+  } else {
+    // Generic C Data Interface array: buffer sizes are not known
+    out->data = (uint8_t*)private_data->src.buffers[i];
+    out->size_bytes = 0;
+    out->capacity_bytes = 0;
+  }
+
+  out->allocator = ArrowBufferDeallocator(&ArrowSharedArrayBufferFree, private_data);
+  return NANOARROW_OK;
 }
 
 static const int kInt32DecimalDigits = 9;
@@ -578,6 +819,7 @@ ArrowErrorCode ArrowDecimalAppendStringToBuffer(const struct ArrowDecimal* decim
 
 #include <errno.h>
 #include <inttypes.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1931,47 +2173,34 @@ ArrowErrorCode ArrowSchemaViewInit(struct ArrowSchemaView* schema_view,
   return NANOARROW_OK;
 }
 
-static int64_t ArrowSchemaTypeToStringInternal(struct ArrowSchemaView* schema_view,
-                                               char* out, int64_t n) {
-  const char* type_string = ArrowTypeString(schema_view->type);
-  switch (schema_view->type) {
-    case NANOARROW_TYPE_DECIMAL32:
-    case NANOARROW_TYPE_DECIMAL64:
-    case NANOARROW_TYPE_DECIMAL128:
-    case NANOARROW_TYPE_DECIMAL256:
-      return snprintf(out, n, "%s(%" PRId32 ", %" PRId32 ")", type_string,
-                      schema_view->decimal_precision, schema_view->decimal_scale);
-    case NANOARROW_TYPE_TIMESTAMP:
-      return snprintf(out, n, "%s('%s', '%s')", type_string,
-                      ArrowTimeUnitString(schema_view->time_unit), schema_view->timezone);
-    case NANOARROW_TYPE_TIME32:
-    case NANOARROW_TYPE_TIME64:
-    case NANOARROW_TYPE_DURATION:
-      return snprintf(out, n, "%s('%s')", type_string,
-                      ArrowTimeUnitString(schema_view->time_unit));
-    case NANOARROW_TYPE_FIXED_SIZE_BINARY:
-    case NANOARROW_TYPE_FIXED_SIZE_LIST:
-      return snprintf(out, n, "%s(%" PRId32 ")", type_string, schema_view->fixed_size);
-    case NANOARROW_TYPE_SPARSE_UNION:
-    case NANOARROW_TYPE_DENSE_UNION:
-      return snprintf(out, n, "%s([%s])", type_string, schema_view->union_type_ids);
-    default:
-      return snprintf(out, n, "%s", type_string);
+static inline void ArrowSchemaToStringSNPrintF(char** out, int64_t* n_remaining,
+                                               int64_t* n_chars, const char* fmt, ...) {
+  // With _FORTIFY_SOURCE=3, vsnprintf on a null output warns, so ensure we never pass
+  // a NULL to vsnprintf
+  char tmp_not_null[1];
+  char* out_not_null;
+  size_t out_not_null_size;
+  if (*out == NULL) {
+    out_not_null = tmp_not_null;
+    out_not_null_size = sizeof(tmp_not_null);
+  } else {
+    out_not_null = *out;
+    out_not_null_size = (size_t)*n_remaining;
   }
-}
 
-// Helper for bookkeeping to emulate sprintf()-like behaviour spread
-// among multiple sprintf calls.
-static inline void ArrowToStringLogChars(char** out, int64_t n_chars_last,
-                                         int64_t* n_remaining, int64_t* n_chars) {
+  va_list args;
+  va_start(args, fmt);
+  int n_chars_last = vsnprintf(out_not_null, out_not_null_size, fmt, args);
+  va_end(args);
+
   // In the unlikely snprintf() returning a negative value (encoding error),
   // ensure the result won't cause an out-of-bounds access.
   if (n_chars_last < 0) {
     n_chars_last = 0;
   }
 
-  *n_chars += n_chars_last;
   *n_remaining -= n_chars_last;
+  *n_chars += n_chars_last;
 
   // n_remaining is never less than 0
   if (*n_remaining < 0) {
@@ -1984,93 +2213,134 @@ static inline void ArrowToStringLogChars(char** out, int64_t n_chars_last,
   }
 }
 
-int64_t ArrowSchemaToString(const struct ArrowSchema* schema, char* out, int64_t n,
-                            char recursive) {
+static void ArrowSchemaTypeToStringInternal(struct ArrowSchemaView* schema_view,
+                                            char** out, int64_t* n_remaining,
+                                            int64_t* n_chars) {
+  const char* type_string = ArrowTypeString(schema_view->type);
+  switch (schema_view->type) {
+    case NANOARROW_TYPE_DECIMAL32:
+    case NANOARROW_TYPE_DECIMAL64:
+    case NANOARROW_TYPE_DECIMAL128:
+    case NANOARROW_TYPE_DECIMAL256:
+      ArrowSchemaToStringSNPrintF(
+          out, n_remaining, n_chars, "%s(%" PRId32 ", %" PRId32 ")", type_string,
+          schema_view->decimal_precision, schema_view->decimal_scale);
+      return;
+    case NANOARROW_TYPE_TIMESTAMP:
+      ArrowSchemaToStringSNPrintF(
+          out, n_remaining, n_chars, "%s('%s', '%s')", type_string,
+          ArrowTimeUnitString(schema_view->time_unit), schema_view->timezone);
+      return;
+    case NANOARROW_TYPE_TIME32:
+    case NANOARROW_TYPE_TIME64:
+    case NANOARROW_TYPE_DURATION:
+      ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars, "%s('%s')", type_string,
+                                  ArrowTimeUnitString(schema_view->time_unit));
+      return;
+    case NANOARROW_TYPE_FIXED_SIZE_BINARY:
+    case NANOARROW_TYPE_FIXED_SIZE_LIST:
+      ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars, "%s(%" PRId32 ")",
+                                  type_string, schema_view->fixed_size);
+      return;
+    case NANOARROW_TYPE_SPARSE_UNION:
+    case NANOARROW_TYPE_DENSE_UNION:
+      ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars, "%s([%s])", type_string,
+                                  schema_view->union_type_ids);
+      return;
+    default:
+      ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars, "%s", type_string);
+      return;
+  }
+}
+
+static void ArrowSchemaToStringInternal(const struct ArrowSchema* schema, char** out,
+                                        int64_t* n_remaining, int64_t* n_chars,
+                                        char recursive) {
   if (schema == NULL) {
-    return snprintf(out, n, "[invalid: pointer is null]");
+    ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars, "[invalid: pointer is null]");
+    return;
   }
 
   if (schema->release == NULL) {
-    return snprintf(out, n, "[invalid: schema is released]");
+    ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars,
+                                "[invalid: schema is released]");
+    return;
   }
 
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
 
   if (ArrowSchemaViewInit(&schema_view, schema, &error) != NANOARROW_OK) {
-    return snprintf(out, n, "[invalid: %s]", ArrowErrorMessage(&error));
+    ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars, "[invalid: %s]",
+                                ArrowErrorMessage(&error));
+    return;
   }
 
   // Extension type and dictionary should include both the top-level type
   // and the storage type.
   int is_extension = schema_view.extension_name.size_bytes > 0;
   int is_dictionary = schema->dictionary != NULL;
-  int64_t n_chars = 0;
-  int64_t n_chars_last = 0;
 
   // Uncommon but not technically impossible that both are true
   if (is_extension && is_dictionary) {
-    n_chars_last = snprintf(
-        out, n, "%.*s{dictionary(%s)<", (int)schema_view.extension_name.size_bytes,
-        schema_view.extension_name.data, ArrowTypeString(schema_view.storage_type));
+    ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars, "%.*s{dictionary(%s)<",
+                                (int)schema_view.extension_name.size_bytes,
+                                schema_view.extension_name.data,
+                                ArrowTypeString(schema_view.storage_type));
   } else if (is_extension) {
-    n_chars_last = snprintf(out, n, "%.*s{", (int)schema_view.extension_name.size_bytes,
-                            schema_view.extension_name.data);
+    ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars, "%.*s{",
+                                (int)schema_view.extension_name.size_bytes,
+                                schema_view.extension_name.data);
   } else if (is_dictionary) {
-    n_chars_last =
-        snprintf(out, n, "dictionary(%s)<", ArrowTypeString(schema_view.storage_type));
+    ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars, "dictionary(%s)<",
+                                ArrowTypeString(schema_view.storage_type));
   }
-
-  ArrowToStringLogChars(&out, n_chars_last, &n, &n_chars);
 
   if (!is_dictionary) {
-    n_chars_last = ArrowSchemaTypeToStringInternal(&schema_view, out, n);
+    ArrowSchemaTypeToStringInternal(&schema_view, out, n_remaining, n_chars);
   } else {
-    n_chars_last = ArrowSchemaToString(schema->dictionary, out, n, recursive);
+    ArrowSchemaToStringInternal(schema->dictionary, out, n_remaining, n_chars, recursive);
   }
 
-  ArrowToStringLogChars(&out, n_chars_last, &n, &n_chars);
-
   if (recursive && schema->format[0] == '+') {
-    n_chars_last = snprintf(out, n, "<");
-    ArrowToStringLogChars(&out, n_chars_last, &n, &n_chars);
+    ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars, "<");
 
     for (int64_t i = 0; i < schema->n_children; i++) {
       if (i > 0) {
-        n_chars_last = snprintf(out, n, ", ");
-        ArrowToStringLogChars(&out, n_chars_last, &n, &n_chars);
+        ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars, ", ");
       }
 
       // ArrowSchemaToStringInternal() will validate the child and print the error,
       // but we need the name first
       if (schema->children[i] != NULL && schema->children[i]->release != NULL &&
           schema->children[i]->name != NULL) {
-        n_chars_last = snprintf(out, n, "%s: ", schema->children[i]->name);
-        ArrowToStringLogChars(&out, n_chars_last, &n, &n_chars);
+        ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars,
+                                    "%s: ", schema->children[i]->name);
       }
 
-      n_chars_last = ArrowSchemaToString(schema->children[i], out, n, recursive);
-      ArrowToStringLogChars(&out, n_chars_last, &n, &n_chars);
+      ArrowSchemaToStringInternal(schema->children[i], out, n_remaining, n_chars,
+                                  recursive);
     }
 
-    n_chars_last = snprintf(out, n, ">");
-    ArrowToStringLogChars(&out, n_chars_last, &n, &n_chars);
+    ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars, ">");
   }
 
   if (is_extension && is_dictionary) {
-    n_chars += snprintf(out, n, ">}");
+    ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars, ">}");
   } else if (is_extension) {
-    n_chars += snprintf(out, n, "}");
+    ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars, "}");
   } else if (is_dictionary) {
-    n_chars += snprintf(out, n, ">");
+    ArrowSchemaToStringSNPrintF(out, n_remaining, n_chars, ">");
   }
+}
 
-  // Ensure that we always return a positive result
-  if (n_chars > 0) {
-    return n_chars;
-  } else {
-    return 0;
-  }
+int64_t ArrowSchemaToString(const struct ArrowSchema* schema, char* out, int64_t n,
+                            char recursive) {
+  NANOARROW_DCHECK(n >= 0);
+  NANOARROW_DCHECK(out != NULL || n == 0);
+  int64_t n_chars = 0;
+  ArrowSchemaToStringInternal(schema, &out, &n, &n_chars, recursive);
+  return n_chars;
 }
 
 ArrowErrorCode ArrowMetadataReaderInit(struct ArrowMetadataReader* reader,
@@ -2328,7 +2598,6 @@ static void ArrowArrayReleaseInternal(struct ArrowArray* array) {
       ArrowBufferReset(&private_data->variadic_buffers[i]);
     }
     ArrowFree(private_data->variadic_buffers);
-    ArrowFree(private_data->variadic_buffer_sizes);
     ArrowFree(private_data);
   }
 
@@ -2362,6 +2631,10 @@ static void ArrowArrayReleaseInternal(struct ArrowArray* array) {
 
   // Mark released
   array->release = NULL;
+}
+
+int ArrowArrayIsInternal(struct ArrowArray* array) {
+  return array->release == &ArrowArrayReleaseInternal;
 }
 
 static ArrowErrorCode ArrowArraySetStorageType(struct ArrowArray* array,
@@ -2460,7 +2733,6 @@ ArrowErrorCode ArrowArrayInitFromType(struct ArrowArray* array,
   }
   private_data->n_variadic_buffers = 0;
   private_data->variadic_buffers = NULL;
-  private_data->variadic_buffer_sizes = NULL;
   private_data->list_view_offset = 0;
 
   array->private_data = private_data;
@@ -2623,25 +2895,35 @@ ArrowErrorCode ArrowArraySetBuffer(struct ArrowArray* array, int64_t i,
   struct ArrowArrayPrivateData* private_data =
       (struct ArrowArrayPrivateData*)array->private_data;
 
-  switch (i) {
-    case 0:
-      ArrowBufferMove(buffer, &private_data->bitmap.buffer);
-      private_data->buffer_data[i] = private_data->bitmap.buffer.data;
-      break;
-    case 1:
-    case 2:
-      ArrowBufferMove(buffer, &private_data->buffers[i - 1]);
-      private_data->buffer_data[i] = private_data->buffers[i - 1].data;
-      break;
-    default:
-      return EINVAL;
+  if (i >= array->n_buffers || i < 0) {
+    return EINVAL;
   }
+
+  // Find the `i`th buffer, release what is currently there, and move the
+  // supplied buffer into that slot.
+  struct ArrowBuffer* dst = ArrowArrayBuffer(array, i);
+  ArrowBufferReset(dst);
+  ArrowBufferMove(buffer, dst);
+
+  // Flush the pointer into array->buffers. In theory clients should call
+  // ArrowArrayFinishBuilding() to flush the pointer values before passing
+  // this array elsewhere; however, in early nanoarrow versions this was not
+  // needed and some code may depend on this being true.
+  private_data->buffer_data[i] = dst->data;
+  array->buffers = private_data->buffer_data;
 
   return NANOARROW_OK;
 }
 
 static ArrowErrorCode ArrowArrayViewInitFromArray(struct ArrowArrayView* array_view,
-                                                  struct ArrowArray* array) {
+                                                  struct ArrowArray* array,
+                                                  struct ArrowError* error) {
+  if (!ArrowArrayIsInternal(array)) {
+    ArrowErrorSet(error,
+                  "Can't initialize internal ArrowArrayView from external ArrowArray");
+    return EINVAL;
+  }
+
   struct ArrowArrayPrivateData* private_data =
       (struct ArrowArrayPrivateData*)array->private_data;
 
@@ -2666,7 +2948,8 @@ static ArrowErrorCode ArrowArrayViewInitFromArray(struct ArrowArrayView* array_v
   }
 
   for (int64_t i = 0; i < array->n_children; i++) {
-    result = ArrowArrayViewInitFromArray(array_view->children[i], array->children[i]);
+    result =
+        ArrowArrayViewInitFromArray(array_view->children[i], array->children[i], error);
     if (result != NANOARROW_OK) {
       ArrowArrayViewReset(array_view);
       return result;
@@ -2680,7 +2963,8 @@ static ArrowErrorCode ArrowArrayViewInitFromArray(struct ArrowArrayView* array_v
       return result;
     }
 
-    result = ArrowArrayViewInitFromArray(array_view->dictionary, array->dictionary);
+    result =
+        ArrowArrayViewInitFromArray(array_view->dictionary, array->dictionary, error);
     if (result != NANOARROW_OK) {
       ArrowArrayViewReset(array_view);
       return result;
@@ -2693,7 +2977,7 @@ static ArrowErrorCode ArrowArrayViewInitFromArray(struct ArrowArrayView* array_v
 static ArrowErrorCode ArrowArrayReserveInternal(struct ArrowArray* array,
                                                 struct ArrowArrayView* array_view) {
   // Loop through buffers and reserve the extra space that we know about
-  for (int64_t i = 0; i < array->n_buffers; i++) {
+  for (int64_t i = 0; i < NANOARROW_MAX_FIXED_BUFFERS; i++) {
     // Don't reserve on a validity buffer that hasn't been allocated yet
     if (array_view->layout.buffer_type[i] == NANOARROW_BUFFER_TYPE_VALIDITY &&
         ArrowArrayBuffer(array, i)->data == NULL) {
@@ -2721,7 +3005,7 @@ static ArrowErrorCode ArrowArrayReserveInternal(struct ArrowArray* array,
 ArrowErrorCode ArrowArrayReserve(struct ArrowArray* array,
                                  int64_t additional_size_elements) {
   struct ArrowArrayView array_view;
-  NANOARROW_RETURN_NOT_OK(ArrowArrayViewInitFromArray(&array_view, array));
+  NANOARROW_RETURN_NOT_OK(ArrowArrayViewInitFromArray(&array_view, array, NULL));
 
   // Calculate theoretical buffer sizes (recursively)
   ArrowArrayViewSetLength(&array_view, array->length + additional_size_elements);
@@ -2753,47 +3037,62 @@ static ArrowErrorCode ArrowArrayFinalizeBuffers(struct ArrowArray* array) {
   }
 
   for (int64_t i = 0; i < array->n_children; i++) {
-    NANOARROW_RETURN_NOT_OK(ArrowArrayFinalizeBuffers(array->children[i]));
+    if (ArrowArrayIsInternal(array->children[i])) {
+      NANOARROW_RETURN_NOT_OK(ArrowArrayFinalizeBuffers(array->children[i]));
+    }
   }
 
-  if (array->dictionary != NULL) {
+  if (array->dictionary != NULL && ArrowArrayIsInternal(array->dictionary)) {
     NANOARROW_RETURN_NOT_OK(ArrowArrayFinalizeBuffers(array->dictionary));
   }
 
   return NANOARROW_OK;
 }
 
-static void ArrowArrayFlushInternalPointers(struct ArrowArray* array) {
+static ArrowErrorCode ArrowArrayFlushInternalPointers(struct ArrowArray* array) {
+  NANOARROW_DCHECK(ArrowArrayIsInternal(array));
   struct ArrowArrayPrivateData* private_data =
       (struct ArrowArrayPrivateData*)array->private_data;
 
-  const bool is_binary_view = private_data->storage_type == NANOARROW_TYPE_STRING_VIEW ||
-                              private_data->storage_type == NANOARROW_TYPE_BINARY_VIEW;
-  const int32_t nfixed_buf = is_binary_view ? 2 : NANOARROW_MAX_FIXED_BUFFERS;
+  if (array->n_buffers > NANOARROW_MAX_FIXED_BUFFERS) {
+    // If the variadic sizes buffer was not set and there is at least one variadic
+    // buffer, populate it now (if there are no variadic buffers there will be exactly
+    // three total buffers and we don't need to do anything special here). Notably, this
+    // will occur when building a BinaryView/StringView array by element using the
+    // appender.
+    struct ArrowBuffer* sizes_buffer = ArrowArrayBuffer(array, array->n_buffers - 1);
+    if (sizes_buffer->data == NULL && sizes_buffer->size_bytes == 0) {
+      NANOARROW_RETURN_NOT_OK(
+          ArrowBufferReserve(sizes_buffer, private_data->n_variadic_buffers));
+      for (int64_t i = 0; i < private_data->n_variadic_buffers; i++) {
+        struct ArrowBuffer* variadic_buffer =
+            ArrowArrayBuffer(array, i + NANOARROW_BINARY_VIEW_FIXED_BUFFERS);
+        NANOARROW_RETURN_NOT_OK(
+            ArrowBufferAppendInt64(sizes_buffer, variadic_buffer->size_bytes));
+      }
+    }
+  }
 
-  for (int32_t i = 0; i < nfixed_buf; i++) {
+  for (int32_t i = 0; i < array->n_buffers; i++) {
     private_data->buffer_data[i] = ArrowArrayBuffer(array, i)->data;
   }
 
-  if (is_binary_view) {
-    const int32_t nvirt_buf = private_data->n_variadic_buffers;
-    private_data->buffer_data = (const void**)ArrowRealloc(
-        private_data->buffer_data, sizeof(void*) * (nfixed_buf + nvirt_buf + 1));
-    for (int32_t i = 0; i < nvirt_buf; i++) {
-      private_data->buffer_data[nfixed_buf + i] = private_data->variadic_buffers[i].data;
-    }
-    private_data->buffer_data[nfixed_buf + nvirt_buf] =
-        private_data->variadic_buffer_sizes;
-    array->buffers = (const void**)(private_data->buffer_data);
-  }
+  array->buffers = (const void**)(private_data->buffer_data);
 
+  // Flush internal pointers for child/dictionary arrays if we allocated them. Clients
+  // building arrays by buffer might have moved arrays from some other source (e.g.,
+  // to create a record batch) and calling this function in that case will cause a crash.
   for (int64_t i = 0; i < array->n_children; i++) {
-    ArrowArrayFlushInternalPointers(array->children[i]);
+    if (ArrowArrayIsInternal(array->children[i])) {
+      NANOARROW_RETURN_NOT_OK(ArrowArrayFlushInternalPointers(array->children[i]));
+    }
   }
 
-  if (array->dictionary != NULL) {
-    ArrowArrayFlushInternalPointers(array->dictionary);
+  if (array->dictionary != NULL && ArrowArrayIsInternal(array->dictionary)) {
+    NANOARROW_RETURN_NOT_OK(ArrowArrayFlushInternalPointers(array->dictionary));
   }
+
+  return NANOARROW_OK;
 }
 
 ArrowErrorCode ArrowArrayFinishBuilding(struct ArrowArray* array,
@@ -2809,7 +3108,7 @@ ArrowErrorCode ArrowArrayFinishBuilding(struct ArrowArray* array,
 
   // Make sure the value we get with array->buffers[i] is set to the actual
   // pointer (which may have changed from the original due to reallocation)
-  ArrowArrayFlushInternalPointers(array);
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayFlushInternalPointers(array), error);
 
   if (validation_level == NANOARROW_VALIDATION_LEVEL_NONE) {
     return NANOARROW_OK;
@@ -2817,8 +3116,8 @@ ArrowErrorCode ArrowArrayFinishBuilding(struct ArrowArray* array,
 
   // For validation, initialize an ArrowArrayView with our known buffer sizes
   struct ArrowArrayView array_view;
-  NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayViewInitFromArray(&array_view, array),
-                                     error);
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+      ArrowArrayViewInitFromArray(&array_view, array, error), error);
   int result = ArrowArrayViewValidate(&array_view, validation_level, error);
   ArrowArrayViewReset(&array_view);
   return result;
@@ -2827,6 +3126,162 @@ ArrowErrorCode ArrowArrayFinishBuilding(struct ArrowArray* array,
 ArrowErrorCode ArrowArrayFinishBuildingDefault(struct ArrowArray* array,
                                                struct ArrowError* error) {
   return ArrowArrayFinishBuilding(array, NANOARROW_VALIDATION_LEVEL_DEFAULT, error);
+}
+
+static int ArrowArrayIsShared(struct ArrowArray* array) {
+  if (!ArrowArrayIsInternal(array)) {
+    return 0;
+  }
+
+  for (int64_t i = 0; i < array->n_buffers; i++) {
+    struct ArrowBuffer* buffer = ArrowArrayBuffer(array, i);
+    if (buffer->data != NULL && !ArrowIsSharedBuffer(buffer)) {
+      return 0;
+    }
+  }
+
+  for (int64_t i = 0; i < array->n_children; i++) {
+    if (!ArrowArrayIsShared(array->children[i])) {
+      return 0;
+    }
+  }
+
+  if (array->dictionary != NULL && !ArrowArrayIsShared(array->dictionary)) {
+    return 0;
+  }
+
+  return 1;
+}
+
+static ArrowErrorCode ArrowArrayMoveSharedInternal(struct ArrowArray* src,
+                                                   struct ArrowArray* dst) {
+  if (ArrowArrayIsShared(src)) {
+    ArrowArrayMove(src, dst);
+    return NANOARROW_OK;
+  }
+
+  NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromType(dst, NANOARROW_TYPE_UNINITIALIZED));
+
+  // Allocate children and move source children to dst children
+  NANOARROW_RETURN_NOT_OK(ArrowArrayAllocateChildren(dst, src->n_children));
+  for (int64_t i = 0; i < src->n_children; i++) {
+    NANOARROW_RETURN_NOT_OK(
+        ArrowArrayMoveSharedInternal(src->children[i], dst->children[i]));
+  }
+
+  // Allocate dictionary if needed and move source dictionary to dst dictionary
+  if (src->dictionary != NULL) {
+    NANOARROW_RETURN_NOT_OK(ArrowArrayAllocateDictionary(dst));
+    NANOARROW_RETURN_NOT_OK(
+        ArrowArrayMoveSharedInternal(src->dictionary, dst->dictionary));
+  }
+
+  // We might need some more buffers if we are shallowly copying a string/binary view
+  if (src->n_buffers > 3) {
+    if (src->n_buffers > INT_MAX) {
+      return EINVAL;
+    }
+
+    NANOARROW_RETURN_NOT_OK(
+        ArrowArrayAddVariadicBuffers(dst, (int32_t)src->n_buffers - 3));
+  }
+
+  // Move src into a shared array and set dst's buffers using the ref-counted version
+  struct ArrowSharedArray shared_array;
+  NANOARROW_RETURN_NOT_OK(ArrowSharedArrayInit(&shared_array, src));
+
+  for (int64_t i = 0; i < src->n_buffers; i++) {
+    struct ArrowBuffer* dst_buffer = ArrowArrayBuffer(dst, i);
+    ArrowErrorCode result = ArrowSharedArrayBuffer(&shared_array, i, dst_buffer);
+    if (result != NANOARROW_OK) {
+      ArrowSharedArrayRelease(&shared_array);
+      return result;
+    }
+  }
+
+  ArrowSharedArrayRelease(&shared_array);
+
+  dst->n_buffers = src->n_buffers;
+  dst->length = src->length;
+  dst->null_count = src->null_count;
+  dst->offset = src->offset;
+
+  // Flush internal buffer pointers to array->buffers
+  NANOARROW_RETURN_NOT_OK(ArrowArrayFlushInternalPointers(dst));
+
+  return NANOARROW_OK;
+}
+
+static ArrowErrorCode ArrowArrayCloneSharedInternal(struct ArrowArray* src,
+                                                    struct ArrowArray* dst) {
+  NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromType(dst, NANOARROW_TYPE_UNINITIALIZED));
+
+  // Allocate children and clone source children to dst children
+  NANOARROW_RETURN_NOT_OK(ArrowArrayAllocateChildren(dst, src->n_children));
+  for (int64_t i = 0; i < src->n_children; i++) {
+    NANOARROW_RETURN_NOT_OK(
+        ArrowArrayCloneSharedInternal(src->children[i], dst->children[i]));
+  }
+
+  // Allocate dictionary if needed and clone source dictionary to dst dictionary
+  if (src->dictionary != NULL) {
+    NANOARROW_RETURN_NOT_OK(ArrowArrayAllocateDictionary(dst));
+    NANOARROW_RETURN_NOT_OK(
+        ArrowArrayCloneSharedInternal(src->dictionary, dst->dictionary));
+  }
+
+  // We might need some more buffers if we are shallowly copying a string/binary view
+  if (src->n_buffers > 3) {
+    if (src->n_buffers > INT_MAX) {
+      return EINVAL;
+    }
+
+    NANOARROW_RETURN_NOT_OK(
+        ArrowArrayAddVariadicBuffers(dst, (int32_t)src->n_buffers - 3));
+  }
+
+  for (int64_t i = 0; i < src->n_buffers; i++) {
+    struct ArrowBuffer* src_buffer = ArrowArrayBuffer(src, i);
+    struct ArrowBuffer* dst_buffer = ArrowArrayBuffer(dst, i);
+    NANOARROW_RETURN_NOT_OK(ArrowSharedBufferClone(src_buffer, dst_buffer));
+  }
+
+  dst->n_buffers = src->n_buffers;
+  dst->length = src->length;
+  dst->null_count = src->null_count;
+  dst->offset = src->offset;
+
+  // Flush internal buffer pointers to array->buffers
+  NANOARROW_RETURN_NOT_OK(ArrowArrayFlushInternalPointers(dst));
+
+  return NANOARROW_OK;
+}
+
+ArrowErrorCode ArrowArrayMoveShared(struct ArrowArray* array, struct ArrowArray* shared) {
+  struct ArrowArray tmp;
+  tmp.release = NULL;
+  ArrowErrorCode result = ArrowArrayMoveSharedInternal(array, shared);
+  if (result != NANOARROW_OK && tmp.release != NULL) {
+    ArrowArrayRelease(&tmp);
+  }
+
+  return result;
+}
+
+ArrowErrorCode ArrowArrayCloneShared(struct ArrowArray* shared,
+                                     struct ArrowArray* array) {
+  if (!ArrowArrayIsShared(shared)) {
+    return EINVAL;
+  }
+
+  struct ArrowArray tmp;
+  tmp.release = NULL;
+  ArrowErrorCode result = ArrowArrayCloneSharedInternal(shared, array);
+  if (result != NANOARROW_OK && tmp.release != NULL) {
+    ArrowArrayRelease(&tmp);
+  }
+
+  return result;
 }
 
 void ArrowArrayViewInitFromType(struct ArrowArrayView* array_view,
@@ -3774,10 +4229,26 @@ static int ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
     NANOARROW_RETURN_NOT_OK(ArrowArrayViewValidateFull(array_view->children[i], error));
   }
 
-  // Dictionary validation not implemented
+  // Dictionary index validation
   if (array_view->dictionary != NULL) {
     NANOARROW_RETURN_NOT_OK(ArrowArrayViewValidateFull(array_view->dictionary, error));
-    // TODO: validate the indices
+
+    // Validate that all non-null indices are within the dictionary bounds
+    int64_t dictionary_length = array_view->dictionary->length;
+    for (int64_t i = 0; i < array_view->length; i++) {
+      if (ArrowArrayViewIsNull(array_view, i)) {
+        continue;
+      }
+
+      int64_t index = ArrowArrayViewGetIntUnsafe(array_view, i);
+      if (index < 0 || index >= dictionary_length) {
+        ArrowErrorSet(error,
+                      "[%" PRId64 "] Expected dictionary index >= 0 and < %" PRId64
+                      " but found value %" PRId64,
+                      i, dictionary_length, index);
+        return EINVAL;
+      }
+    }
   }
 
   return NANOARROW_OK;
@@ -4040,6 +4511,7 @@ ArrowErrorCode ArrowBasicArrayStreamInit(struct ArrowArrayStream* array_stream,
         (struct ArrowArray*)ArrowMalloc(n_arrays * sizeof(struct ArrowArray));
     if (private_data->arrays == NULL) {
       ArrowBasicArrayStreamRelease(array_stream);
+      ArrowFree(private_data);
       return ENOMEM;
     }
   }

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -19,9 +19,9 @@
 #define NANOARROW_CONFIG_H_INCLUDED
 
 #define NANOARROW_VERSION_MAJOR 0
-#define NANOARROW_VERSION_MINOR 7
+#define NANOARROW_VERSION_MINOR 9
 #define NANOARROW_VERSION_PATCH 0
-#define NANOARROW_VERSION "0.7.0"
+#define NANOARROW_VERSION "0.9.0-SNAPSHOT"
 
 #define NANOARROW_VERSION_INT                                        \
   (NANOARROW_VERSION_MAJOR * 10000 + NANOARROW_VERSION_MINOR * 100 + \
@@ -181,6 +181,13 @@ struct ArrowArrayStream {
     if (NAME) return NAME;                        \
   } while (0)
 
+// __COUNTER__ is not guaranteed to be available and some compiler warnings may occur
+// if we use it (-Wc2y-extensions). We don't strictly need it because of the
+// do { ... } while(0) scoping and because we never need the return value to live
+// outside the temporary scope. Here we define a suffix that is unlikely to collide
+// with anything in EXPR.
+#define _NANOARROW_UNIQUE_SUFFIX _nanoarrow_unique_suffix
+
 #define _NANOARROW_CHECK_RANGE(x_, min_, max_) \
   NANOARROW_RETURN_NOT_OK((x_ >= min_ && x_ <= max_) ? NANOARROW_OK : EINVAL)
 
@@ -305,7 +312,8 @@ static inline void ArrowErrorSetString(struct ArrowError* error, const char* src
 /// \brief Check the result of an expression and return it if not NANOARROW_OK
 /// \ingroup nanoarrow-errors
 #define NANOARROW_RETURN_NOT_OK(EXPR) \
-  _NANOARROW_RETURN_NOT_OK_IMPL(_NANOARROW_MAKE_NAME(errno_status_, __COUNTER__), EXPR)
+  _NANOARROW_RETURN_NOT_OK_IMPL(      \
+      _NANOARROW_MAKE_NAME(errno_status_, _NANOARROW_UNIQUE_SUFFIX), EXPR)
 
 /// \brief Check the result of an expression and return it if not NANOARROW_OK,
 /// adding an auto-generated message to an ArrowError.
@@ -314,9 +322,10 @@ static inline void ArrowErrorSetString(struct ArrowError* error, const char* src
 /// This macro is used to ensure that functions that accept an ArrowError
 /// as input always set its message when returning an error code (e.g., when calling
 /// a nanoarrow function that does *not* accept ArrowError).
-#define NANOARROW_RETURN_NOT_OK_WITH_ERROR(EXPR, ERROR_EXPR) \
-  _NANOARROW_RETURN_NOT_OK_WITH_ERROR_IMPL(                  \
-      _NANOARROW_MAKE_NAME(errno_status_, __COUNTER__), EXPR, ERROR_EXPR, #EXPR)
+#define NANOARROW_RETURN_NOT_OK_WITH_ERROR(EXPR, ERROR_EXPR)                           \
+  _NANOARROW_RETURN_NOT_OK_WITH_ERROR_IMPL(                                            \
+      _NANOARROW_MAKE_NAME(errno_status_, _NANOARROW_UNIQUE_SUFFIX), EXPR, ERROR_EXPR, \
+      #EXPR)
 
 #if defined(NANOARROW_DEBUG) && !defined(NANOARROW_PRINT_AND_DIE)
 #define NANOARROW_PRINT_AND_DIE(VALUE, EXPR_STR)                                 \
@@ -343,7 +352,8 @@ static inline void ArrowErrorSetString(struct ArrowError* error, const char* src
 /// be defining the NANOARROW_PRINT_AND_DIE macro before including nanoarrow.h
 /// This macro is provided as a convenience for users and is not used internally.
 #define NANOARROW_ASSERT_OK(EXPR) \
-  _NANOARROW_ASSERT_OK_IMPL(_NANOARROW_MAKE_NAME(errno_status_, __COUNTER__), EXPR, #EXPR)
+  _NANOARROW_ASSERT_OK_IMPL(      \
+      _NANOARROW_MAKE_NAME(errno_status_, _NANOARROW_UNIQUE_SUFFIX), EXPR, #EXPR)
 
 #define _NANOARROW_DCHECK_IMPL(EXPR, EXPR_STR)          \
   do {                                                  \
@@ -502,7 +512,7 @@ enum ArrowType {
 /// \brief Get a string value of an enum ArrowType value
 /// \ingroup nanoarrow-utils
 ///
-/// Returns NULL for invalid values for type
+/// Returns "<unknown type identifier>" for invalid values for type
 static inline const char* ArrowTypeString(enum ArrowType type);
 
 static inline const char* ArrowTypeString(enum ArrowType type) {
@@ -598,7 +608,7 @@ static inline const char* ArrowTypeString(enum ArrowType type) {
     case NANOARROW_TYPE_LARGE_LIST_VIEW:
       return "large_list_view";
     default:
-      return "<invalid type identifier>";
+      return "<unknown type identifier>";
   }
 }
 
@@ -909,9 +919,6 @@ struct ArrowArrayPrivateData {
   // Variadic buffers for binary view types
   struct ArrowBuffer* variadic_buffers;
 
-  // Size of each variadic buffer in bytes
-  int64_t* variadic_buffer_sizes;
-
   // The current offset used to build list views
   int64_t list_view_offset;
 };
@@ -1133,6 +1140,17 @@ static inline void ArrowDecimalSetBytes(struct ArrowDecimal* decimal,
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowBufferAllocatorDefault)
 #define ArrowBufferDeallocator \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowBufferDeallocator)
+#define ArrowSharedBufferInit NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowSharedBufferInit)
+#define ArrowSharedBufferIsThreadSafe \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowSharedBufferIsThreadSafe)
+#define ArrowSharedBufferClone \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowSharedBufferClone)
+#define ArrowSharedArrayInit NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowSharedArrayInit)
+#define ArrowSharedArrayRelease \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowSharedArrayRelease)
+#define ArrowSharedArrayBuffer \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowSharedArrayBuffer)
+#define ArrowIsSharedBuffer NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIsSharedBuffer)
 #define ArrowErrorSet NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowErrorSet)
 #define ArrowLayoutInit NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowLayoutInit)
 #define ArrowDecimalSetDigits NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowDecimalSetDigits)
@@ -1182,6 +1200,7 @@ static inline void ArrowDecimalSetBytes(struct ArrowDecimal* decimal,
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowMetadataBuilderRemove)
 #define ArrowSchemaViewInit NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowSchemaViewInit)
 #define ArrowSchemaToString NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowSchemaToString)
+#define ArrowArrayIsInternal NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayIsInternal)
 #define ArrowArrayInitFromType \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayInitFromType)
 #define ArrowArrayInitFromSchema \
@@ -1202,6 +1221,8 @@ static inline void ArrowDecimalSetBytes(struct ArrowDecimal* decimal,
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayFinishBuilding)
 #define ArrowArrayFinishBuildingDefault \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayFinishBuildingDefault)
+#define ArrowArrayMoveShared NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayMoveShared)
+#define ArrowArrayCloneShared NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayCloneShared)
 #define ArrowArrayViewInitFromType \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayViewInitFromType)
 #define ArrowArrayViewInitFromSchema \
@@ -1291,6 +1312,85 @@ NANOARROW_DLL struct ArrowBufferAllocator ArrowBufferDeallocator(
 
 /// @}
 
+/// \defgroup nanoarrow-shared-buffer Shared buffers and arrays
+///
+/// The nanoarrow library implements two kinds of shared buffers: those backed by
+/// a reference-counted ArrowBuffer and those backed by a reference-counted ArrowArray.
+/// These are useful for building ArrowArrays using buffers without copying the bytes
+/// of the source. For example the IPC implementation uses shared buffers derived from an
+/// ArrowBuffer to avoid copying buffers from an IPC message, and the Shared buffers
+/// derived from arrays are used to make a safe shallow clone of an array.
+///
+/// Reference counts are implemented using C11 atomics and not necessarily thread safe
+/// on all platforms (notably, MSVC requires `/experimental:c11atomics`). Use
+/// ArrowSharedBufferIsThreadSafe() to check for thread safety if this is needed.
+///
+/// @{
+
+/// \brief Initialize a shared buffer from an ArrowBuffer
+///
+/// If NANOARROW_OK is returned, shared is a reference-counted buffer that
+/// took ownership of src. The caller should release the shared buffer
+/// using ArrowBufferReset() when finished. The underlying data will persist
+/// until all clones have also been released.
+NANOARROW_DLL ArrowErrorCode ArrowSharedBufferInit(struct ArrowBuffer* shared,
+                                                   struct ArrowBuffer* src);
+
+/// \brief Check for shared buffer thread safety
+///
+/// Thread-safe shared buffers require C11 and the stdatomic.h header.
+/// If either are unavailable, shared buffers are still possible but
+/// the resulting arrays must not be passed to other threads to be released.
+NANOARROW_DLL int ArrowSharedBufferIsThreadSafe(void);
+
+/// \brief Check if a buffer is a shared buffer
+///
+/// Returns non-zero if buffer was created by ArrowSharedBufferInit() or
+/// obtained from ArrowSharedArrayBuffer().
+NANOARROW_DLL int ArrowIsSharedBuffer(struct ArrowBuffer* buffer);
+
+/// \brief Clone a shared buffer, incrementing its reference count
+///
+/// This creates a new ArrowBuffer that shares the same underlying data with the
+/// original shared buffer. The reference count is incremented. Returns EINVAL
+/// if shared is not a shared buffer (i.e. ArrowIsSharedBuffer() returns false).
+NANOARROW_DLL ArrowErrorCode ArrowSharedBufferClone(struct ArrowBuffer* shared,
+                                                    struct ArrowBuffer* shared_out);
+
+/// \brief An opaque handle to a shared, reference-counted ArrowArray
+struct ArrowSharedArray {
+  void* private_data;
+};
+
+/// \brief Initialize a shared array from an ArrowArray
+///
+/// Takes ownership of src (sets src->release to NULL). The shared array
+/// should be released with ArrowSharedArrayRelease() when all buffers have
+/// been extracted from the source. The original array will be released
+/// when all borrowed buffers have been released.
+NANOARROW_DLL ArrowErrorCode ArrowSharedArrayInit(struct ArrowSharedArray* shared,
+                                                  struct ArrowArray* src);
+
+/// \brief Release the caller's reference to a shared array
+///
+/// Decrements the reference count. When no more references remain
+/// (including any buffers obtained via ArrowSharedArrayBuffer()),
+/// the underlying ArrowArray is released.
+NANOARROW_DLL void ArrowSharedArrayRelease(struct ArrowSharedArray* shared);
+
+/// \brief Obtain a buffer from a shared array
+///
+/// Returns an ArrowBuffer that views buffer i of the underlying ArrowArray.
+/// If the source array was built with nanoarrow (i.e. ArrowArrayIsInternal()
+/// returns true), buffer sizes are known and propagated to the output.
+/// Otherwise the output buffer's size_bytes will be 0. The shared array's
+/// reference count is incremented. The returned buffer is compatible with
+/// ArrowSharedBufferClone().
+NANOARROW_DLL ArrowErrorCode ArrowSharedArrayBuffer(struct ArrowSharedArray* shared,
+                                                    int64_t i, struct ArrowBuffer* out);
+
+/// @}
+
 /// \brief Move the contents of an src ArrowSchema into dst and set src->release to NULL
 /// \ingroup nanoarrow-arrow-cdata
 static inline void ArrowSchemaMove(struct ArrowSchema* src, struct ArrowSchema* dst);
@@ -1322,7 +1422,7 @@ static inline ArrowErrorCode ArrowArrayStreamGetSchema(
     struct ArrowArrayStream* array_stream, struct ArrowSchema* out,
     struct ArrowError* error);
 
-/// \brief Call the get_schema callback of an ArrowArrayStream
+/// \brief Call the get_next callback of an ArrowArrayStream
 /// \ingroup nanoarrow-arrow-cdata
 ///
 /// Unlike the get_next callback, this wrapper checks the return code
@@ -1333,12 +1433,13 @@ static inline ArrowErrorCode ArrowArrayStreamGetNext(
     struct ArrowArrayStream* array_stream, struct ArrowArray* out,
     struct ArrowError* error);
 
-/// \brief Call the get_next callback of an ArrowArrayStream
+/// \brief Call the get_last_error callback of an ArrowArrayStream
 /// \ingroup nanoarrow-arrow-cdata
 ///
-/// Unlike the get_next callback, this function never returns NULL (i.e., its
-/// result is safe to use in printf-style error formatters). Null values from the
-/// original callback are reported as "<get_last_error() returned NULL>".
+/// Unlike the get_last_error callback, this function never returns NULL (i.e.,
+/// its result is safe to use in printf-style error formatters). Null values
+/// from the original callback are reported as
+/// "<get_last_error() returned NULL>".
 static inline const char* ArrowArrayStreamGetLastError(
     struct ArrowArrayStream* array_stream);
 
@@ -1993,6 +2094,12 @@ NANOARROW_DLL void ArrowArraySetValidityBitmap(struct ArrowArray* array,
 NANOARROW_DLL ArrowErrorCode ArrowArraySetBuffer(struct ArrowArray* array, int64_t i,
                                                  struct ArrowBuffer* buffer);
 
+/// \brief Add variadic buffers to a string or binary view array
+///
+/// array must have been allocated using ArrowArrayInitFromType()
+static inline ArrowErrorCode ArrowArrayAddVariadicBuffers(struct ArrowArray* array,
+                                                          int32_t n_buffers);
+
 /// \brief Get the validity bitmap of an ArrowArray
 ///
 /// array must have been allocated using ArrowArrayInitFromType()
@@ -2119,6 +2226,12 @@ static inline ArrowErrorCode ArrowArrayShrinkToFit(struct ArrowArray* array);
 NANOARROW_DLL ArrowErrorCode ArrowArrayFinishBuildingDefault(struct ArrowArray* array,
                                                              struct ArrowError* error);
 
+/// \brief Check if an ArrowArray was allocated by nanoarrow
+///
+/// Returns non-zero if array was allocated using ArrowArrayInitFromType(),
+/// ArrowArrayInitFromSchema(), or ArrowArrayInitFromArrayView().
+NANOARROW_DLL int ArrowArrayIsInternal(struct ArrowArray* array);
+
 /// \brief Finish building an ArrowArray with explicit validation
 ///
 /// Finish building with an explicit validation level. This could perform less validation
@@ -2129,6 +2242,25 @@ NANOARROW_DLL ArrowErrorCode ArrowArrayFinishBuildingDefault(struct ArrowArray* 
 NANOARROW_DLL ArrowErrorCode ArrowArrayFinishBuilding(
     struct ArrowArray* array, enum ArrowValidationLevel validation_level,
     struct ArrowError* error);
+
+/// \brief Create a shared copy of an ArrowArray
+///
+/// Recursively converts array into a version where all buffers are
+/// reference-counted. On success, shared is a new ArrowArray whose buffers
+/// are backed by ArrowSharedArray references, and array is consumed
+/// (release set to NULL). The resulting shared array can be safely moved
+/// or have its buffers cloned via ArrowSharedBufferClone().
+NANOARROW_DLL ArrowErrorCode ArrowArrayMoveShared(struct ArrowArray* array,
+                                                  struct ArrowArray* shared);
+
+/// \brief Clone a shared ArrowArray
+///
+/// Creates a new ArrowArray whose buffers share the same underlying data as
+/// the source shared array. The source must have been created by
+/// ArrowArrayMoveShared() (i.e. all buffers are reference-counted).
+/// Returns EINVAL if shared is not a shared array.
+NANOARROW_DLL ArrowErrorCode ArrowArrayCloneShared(struct ArrowArray* shared,
+                                                   struct ArrowArray* array);
 
 /// @}
 
@@ -2332,8 +2464,8 @@ NANOARROW_DLL ArrowErrorCode ArrowBasicArrayStreamInit(
 /// \brief Set the ith ArrowArray in this ArrowArrayStream.
 ///
 /// array_stream must have been initialized with ArrowBasicArrayStreamInit().
-/// This function move the ownership of array to the array_stream. i must
-/// be greater than zero and less than the value of n_arrays passed in
+/// This function moves the ownership of array to the array_stream. i must
+/// be greater than or equal to zero and less than the value of n_arrays passed in
 /// ArrowBasicArrayStreamInit(). Callers are not required to fill all
 /// n_arrays members (i.e., n_arrays is a maximum bound).
 NANOARROW_DLL void ArrowBasicArrayStreamSetArray(struct ArrowArrayStream* array_stream,
@@ -3139,8 +3271,25 @@ static inline struct ArrowBuffer* ArrowArrayBuffer(struct ArrowArray* array, int
   switch (i) {
     case 0:
       return &private_data->bitmap.buffer;
+    case 1:
+      return private_data->buffers;
     default:
-      return private_data->buffers + i - 1;
+      if (array->n_buffers > 3 && i == (array->n_buffers - 1)) {
+        // The variadic buffer sizes buffer if for a BinaryView/String view array
+        // is always stored in private_data->buffers[1]; however, from the numbered
+        // buffers perspective this is the array->buffers[array->n_buffers - 1].
+        return private_data->buffers + 1;
+      } else if (array->n_buffers > 3) {
+        // If there are one or more variadic buffers, they are stored in
+        // private_data->variadic_buffers
+        return private_data->variadic_buffers + (i - 2);
+      } else {
+        // Otherwise, we're just accessing buffer at index 2 (e.g., String/Binary
+        // data buffer or variadic sizes buffer for the case where there are no
+        // variadic buffers)
+        NANOARROW_DCHECK(i == 2);
+        return private_data->buffers + i - 1;
+      }
   }
 }
 
@@ -3373,49 +3522,65 @@ static inline ArrowErrorCode _ArrowArrayAppendEmptyInternal(struct ArrowArray* a
   }
 
   // Add appropriate buffer fill
-  struct ArrowBuffer* buffer;
-  int64_t size_bytes;
-
   for (int i = 0; i < NANOARROW_MAX_FIXED_BUFFERS; i++) {
-    buffer = ArrowArrayBuffer(array, i);
-    size_bytes = private_data->layout.element_size_bits[i] / 8;
+    struct ArrowBuffer* buffer = ArrowArrayBuffer(array, i);
+    int64_t size_bytes = private_data->layout.element_size_bits[i] / 8;
 
     switch (private_data->layout.buffer_type[i]) {
       case NANOARROW_BUFFER_TYPE_NONE:
       case NANOARROW_BUFFER_TYPE_VARIADIC_DATA:
       case NANOARROW_BUFFER_TYPE_VARIADIC_SIZE:
       case NANOARROW_BUFFER_TYPE_VALIDITY:
-        continue;
+        // These buffer types don't require initialization for empty appends:
+        // - NONE: No buffer exists
+        // - VARIADIC_*: Handled by child arrays
+        // - VALIDITY: Already handled in previous bitmap logic
+        break;
+
       case NANOARROW_BUFFER_TYPE_SIZE:
+        // Size buffers (e.g., string/array lengths) should be zero-initialized:
+        // This ensures empty elements have logical zero-length
         NANOARROW_RETURN_NOT_OK(ArrowBufferAppendFill(buffer, 0, size_bytes * n));
-        continue;
+        break;
+
       case NANOARROW_BUFFER_TYPE_DATA_OFFSET:
-        // Append the current value at the end of the offset buffer for each element
+        // Offset buffers require special handling to maintain continuity.
+        // 1. Reserve space for new offset entries
         NANOARROW_RETURN_NOT_OK(ArrowBufferReserve(buffer, size_bytes * n));
 
+        // 2. Duplicate last offset value for each new (empty) element
         for (int64_t j = 0; j < n; j++) {
           ArrowBufferAppendUnsafe(buffer, buffer->data + size_bytes * (array->length + j),
                                   size_bytes);
         }
 
-        // Skip the data buffer
+        // 3. Skip next buffer (DATA) since it's paired with offsets
+        //    Rationale: Offset buffers are always followed by data buffers
+        //    that don't require separate initialization here
         i++;
-        continue;
+        break;
+
       case NANOARROW_BUFFER_TYPE_DATA:
-        // Zero out the next bit of memory
+        // Fixed-width data buffers require zero-initialization:
         if (private_data->layout.element_size_bits[i] % 8 == 0) {
+          // Byte-aligned: use efficient memset-style fill
           NANOARROW_RETURN_NOT_OK(ArrowBufferAppendFill(buffer, 0, size_bytes * n));
         } else {
+          // Bit-packed: use special bitwise initialization
           NANOARROW_RETURN_NOT_OK(_ArrowArrayAppendBits(array, i, 0, n));
         }
-        continue;
+        break;
+
       case NANOARROW_BUFFER_TYPE_VIEW_OFFSET:
+        // View offset buffers (for string/binary view types) require zero-initialization.
         NANOARROW_RETURN_NOT_OK(ArrowBufferReserve(buffer, size_bytes * n));
         NANOARROW_RETURN_NOT_OK(ArrowBufferAppendFill(buffer, 0, size_bytes * n));
-        continue;
+        break;
+
       case NANOARROW_BUFFER_TYPE_TYPE_ID:
       case NANOARROW_BUFFER_TYPE_UNION_OFFSET:
-        // These cases return above
+        // These buffer types should have been handled by the outer type switch and
+        // are not expected here, indicating an internal logic error.
         return EINVAL;
     }
   }
@@ -3607,9 +3772,9 @@ static inline int32_t ArrowArrayVariadicBufferCount(struct ArrowArray* array) {
 }
 
 static inline ArrowErrorCode ArrowArrayAddVariadicBuffers(struct ArrowArray* array,
-                                                          int32_t nbuffers) {
+                                                          int32_t n_buffers) {
   const int32_t n_current_bufs = ArrowArrayVariadicBufferCount(array);
-  const int32_t nvariadic_bufs_needed = n_current_bufs + nbuffers;
+  const int32_t nvariadic_bufs_needed = n_current_bufs + n_buffers;
 
   struct ArrowArrayPrivateData* private_data =
       (struct ArrowArrayPrivateData*)array->private_data;
@@ -3619,19 +3784,24 @@ static inline ArrowErrorCode ArrowArrayAddVariadicBuffers(struct ArrowArray* arr
   if (private_data->variadic_buffers == NULL) {
     return ENOMEM;
   }
-  private_data->variadic_buffer_sizes = (int64_t*)ArrowRealloc(
-      private_data->variadic_buffer_sizes, sizeof(int64_t) * nvariadic_bufs_needed);
-  if (private_data->variadic_buffer_sizes == NULL) {
-    return ENOMEM;
-  }
 
-  for (int32_t i = n_current_bufs; i < nvariadic_bufs_needed; i++) {
-    ArrowBufferInit(&private_data->variadic_buffers[i]);
-    private_data->variadic_buffer_sizes[i] = 0;
-  }
   private_data->n_variadic_buffers = nvariadic_bufs_needed;
   array->n_buffers = NANOARROW_BINARY_VIEW_FIXED_BUFFERS + 1 + nvariadic_bufs_needed;
 
+  private_data->buffer_data = (const void**)ArrowRealloc(
+      private_data->buffer_data, array->n_buffers * sizeof(void*));
+
+  for (int32_t i = n_current_bufs; i < nvariadic_bufs_needed; i++) {
+    ArrowBufferInit(&private_data->variadic_buffers[i]);
+    private_data->buffer_data[NANOARROW_BINARY_VIEW_FIXED_BUFFERS + i] = NULL;
+  }
+
+  // Zero out memory for the final buffer (variadic sizes buffer we haven't built yet)
+  private_data->buffer_data[NANOARROW_BINARY_VIEW_FIXED_BUFFERS + nvariadic_bufs_needed] =
+      NULL;
+
+  // Ensure array->buffers points to a valid value
+  array->buffers = private_data->buffer_data;
   return NANOARROW_OK;
 }
 
@@ -3669,7 +3839,6 @@ static inline ArrowErrorCode ArrowArrayAppendBytes(struct ArrowArray* array,
       bvt.ref.offset = (int32_t)variadic_buf->size_bytes;
       NANOARROW_RETURN_NOT_OK(
           ArrowBufferAppend(variadic_buf, value.data.as_char, value.size_bytes));
-      private_data->variadic_buffer_sizes[buf_index] = variadic_buf->size_bytes;
     }
     NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(data_buffer, &bvt, sizeof(bvt)));
   } else {
@@ -4174,6 +4343,7 @@ static inline int64_t ArrowArrayViewListChildOffset(
     const struct ArrowArrayView* array_view, int64_t i) {
   switch (array_view->storage_type) {
     case NANOARROW_TYPE_LIST:
+    case NANOARROW_TYPE_MAP:
     case NANOARROW_TYPE_LIST_VIEW:
       return array_view->buffer_views[1].data.as_int32[i];
     case NANOARROW_TYPE_LARGE_LIST:

--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -69,7 +69,7 @@ NANOARROW_CXX_NAMESPACE_BEGIN
 class Exception : public std::exception {
  public:
   Exception(const std::string& msg) : msg_(msg) {}
-  const char* what() const noexcept { return msg_.c_str(); }
+  const char* what() const noexcept override { return msg_.c_str(); }
 
  private:
   std::string msg_;
@@ -98,9 +98,9 @@ class Exception : public std::exception {
   } while (0)
 #endif
 
-#define NANOARROW_THROW_NOT_OK(EXPR)                                                   \
-  _NANOARROW_THROW_NOT_OK_IMPL(_NANOARROW_MAKE_NAME(errno_status_, __COUNTER__), EXPR, \
-                               #EXPR)
+#define NANOARROW_THROW_NOT_OK(EXPR) \
+  _NANOARROW_THROW_NOT_OK_IMPL(      \
+      _NANOARROW_MAKE_NAME(errno_status_, _NANOARROW_UNIQUE_SUFFIX), EXPR, #EXPR)
 
 /// @}
 
@@ -861,7 +861,7 @@ class ViewArrayAs {
   using const_iterator = typename internal::RandomAccessRange<Get>::const_iterator;
   const_iterator begin() const { return range_.begin(); }
   const_iterator end() const { return range_.end(); }
-  value_type operator[](int64_t i) const { return range_.get(i); }
+  value_type operator[](int64_t i) const { return range_.get(range_.offset + i); }
 };
 
 /// \brief A range-for compatible wrapper for ArrowArray of binary or utf8

--- a/vendor-nanoarrow.sh
+++ b/vendor-nanoarrow.sh
@@ -1,7 +1,7 @@
 main() {
-  local -r repo_url="https://github.com/apache/arrow-nanoarrow"
+  local -r repo_url="https://github.com/paleolimbot/arrow-nanoarrow"
   # Check releases page: https://github.com/apache/arrow-nanoarrow/releases/
-  local -r commit_sha=2cfba631b40886f1418a463f3b7c4552c8ae0dc7
+  local -r commit_sha=99618838a17efdbd1b387c186f6698a255673bae
 
   echo "Fetching $commit_sha from $repo_url"
   SCRATCH=$(mktemp -d)


### PR DESCRIPTION
It turns out we need the latest nanoarrow PR to fix the current CRAN issue (warning on gcc16).